### PR TITLE
Fix for macOS > 10.12

### DIFF
--- a/libexec/helpers
+++ b/libexec/helpers
@@ -18,7 +18,7 @@ function curlw () {
   local TLS_OPT="--tlsv1.2"
 
   # Check if curl is 10.12.6 or above
-  if [[ -n "$(which sw_vers 2>/dev/null)" && "$(sw_vers)" =~ 10\.12\.([6-9]|[0-9]{2}) ]]; then
+  if [[ -n "$(which sw_vers 2>/dev/null)" && ("$(sw_vers)" =~ 10\.12\.([6-9]|[0-9]{2}) || "$(sw_vers)" =~ 10\.1[3-9]) ]]; then
     TLS_OPT=""
   fi
 


### PR DESCRIPTION
With macOS 10.13 the old fix won't work anymore. Updated the regex to also work for versions up to 10.19