### PR TITLE
Alpha releases not shown, list broken

### DIFF
--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -8,4 +8,4 @@ if [ ${#} -ne 0 ];then
   exit 1
 fi
 
-curlw -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq
+curlw -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)[0-9]+)?" | uniq


### PR DESCRIPTION
The regex picks only the first part of the release without considering the alpha. This doesn't show the alpha releases and breaks the remote list since 0.12.0 does not exist yet.